### PR TITLE
Replace `string.docstring` by `docstring` only

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -331,7 +331,7 @@ repository:
         endCaptures:
           '1':
             'name': 'punctuation.definition.string.end.julia'
-        name: 'string.docstring.julia'
+        name: 'docstring.julia'
         contentName : 'source.gfm'
         comment: """
         This only matches docstrings that start and end with triple quotes on
@@ -473,7 +473,7 @@ repository:
             'name': 'punctuation.definition.string.end.julia'
           '2':
             'name': 'keyword.operator.arrow.julia'
-        name: 'string.docstring.julia'
+        name: 'docstring.julia'
         contentName : 'source.gfm'
         patterns: [
           {

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -89,8 +89,8 @@ describe "Julia grammar", ->
 
   it "tokenizes docstrings", ->
     {tokens} = grammar.tokenizeLine("@doc doc\"\"\" xx *x* \"\"\" ->")
-    expect(tokens[0]).toEqual value: "@doc", scopes: ["source.julia", "string.docstring.julia", "support.function.macro.julia"]
-    expect(tokens[2]).toEqual value: "doc\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[0]).toEqual value: "@doc", scopes: ["source.julia", "docstring.julia", "support.function.macro.julia"]
+    expect(tokens[2]).toEqual value: "doc\"\"\"", scopes: ["source.julia", "docstring.julia", "punctuation.definition.string.begin.julia"]
 
   it "tokenizes void docstrings", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
@@ -99,9 +99,9 @@ describe "Julia grammar", ->
     foo bar
     \"\"\"
     """)
-    expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
-    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "docstring.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "docstring.julia", "source.gfm"]
+    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "docstring.julia", "punctuation.definition.string.end.julia"]
 
   # code is a line from Gadfly.jl -- with the interpolation taken out
   it "tokenizes function calls starting with double quotes", ->


### PR DESCRIPTION
This removes the `string` attribute in `docstrings`, as @spencerlyon2 suggested in #33 

The specs have been updated too
