### PR TITLE
[RFC] Support embedded JSON and YAML string literals

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -337,6 +337,44 @@ repository:
         ]
       }
       {
+        begin: "(i?json)(\"\"\")"
+        beginCaptures:
+          "1":
+            name: "support.function.macro.julia"
+          "2":
+            name: "punctuation.definition.string.begin.julia"
+        end: "\"\"\""
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        name: 'embed.json.julia'
+        contentName: 'source.json'
+        patterns: [
+          {
+            include: 'source.json'
+          }
+        ]
+      }
+      {
+        begin: "(i?yaml)(\"\"\")"
+        beginCaptures:
+          "1":
+            name: "support.function.macro.julia"
+          "2":
+            name: "punctuation.definition.string.begin.julia"
+        end: "\"\"\""
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        name: 'embed.yaml.julia'
+        contentName: 'source.yaml'
+        patterns: [
+          {
+            include: 'source.yaml'
+          }
+        ]
+      }
+      {
         begin: '^\\s?([[:alpha:]_][[:word:]!]*)?(""")\\s?$'
         beginCaptures:
           '1':

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -277,6 +277,29 @@ describe "Julia grammar", ->
     expect(tokens[2]).toEqual value: 'std::string', scopes: ["source.julia", "embed.cxx.julia", "source.cpp"]
     expect(tokens[3]).toEqual value: '"', scopes: ["source.julia", "embed.cxx.julia", "punctuation.definition.string.end.julia"]
 
+  it "tokenizes JSON multiline string macros", ->
+    tokens = grammar.tokenizeLines('''
+    json"""
+    {"a": 55}
+    """
+    ''')
+    expect(tokens[0][0]).toEqual value: 'json', scopes: ["source.julia", "embed.json.julia", "support.function.macro.julia"]
+    expect(tokens[0][1]).toEqual value: '"""', scopes: ["source.julia", "embed.json.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1][0]).toEqual value: '{"a": 55}', scopes: ["source.julia", "embed.json.julia", "source.json"]
+    expect(tokens[2][0]).toEqual value: '"""', scopes: ["source.julia", "embed.json.julia", "punctuation.definition.string.end.julia"]
+
+  it "tokenizes YAML multiline string macros", ->
+    tokens = grammar.tokenizeLines('''
+    yaml"""
+    a: 55
+    """
+    ''')
+    expect(tokens[0][0]).toEqual value: 'yaml', scopes: ["source.julia", "embed.yaml.julia", "support.function.macro.julia"]
+    expect(tokens[0][1]).toEqual value: '"""', scopes: ["source.julia", "embed.yaml.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1][0]).toEqual value: 'a: 55', scopes: ["source.julia", "embed.yaml.julia", "source.yaml"]
+    expect(tokens[2][0]).toEqual value: '"""', scopes: ["source.julia", "embed.yaml.julia", "punctuation.definition.string.end.julia"]
+
+
   it "tokenizes symbols of `keyword.other`s", ->
     {tokens} = grammar.tokenizeLine(':type')
     expect(tokens[0]).toEqual value: ':', scopes: ["source.julia", "keyword.operator.ternary.julia"]


### PR DESCRIPTION
We already have support for `cxx""" ... """`. This adds support for similar embedded styling for JSON and YAML, ala:

``` julia
a = yaml"""
one: 123
two:
  twoA: hello
  twoB: world
"""
```

If we add something similar to https://github.com/JuliaLang/Julia.tmbundle, we can cover Atom, TextMate, Sublime, and GitHub markup (so the block above will have enhanced highlighting).

Note, JSON and YAML string literals aren't in JSON.jl (https://github.com/JuliaLang/JSON.jl/pull/113) and YAML.jl, yet. So, we should probably wait to get some consensus here.

This feature helps for including structured data in the same file as the Julia source code.
