### PR TITLE
Fix autoindentation bug in comments and strings

### DIFF
--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -3,7 +3,7 @@
     commentStart: "# "
 ".source.julia:not(.string)":
   editor:
-    increaseIndentPattern: "(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
+    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*(if|while|for|function|macro|immutable|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
     foldingStartMarker: "^\\s*(?:if|while|for|begin|function|macro|module|baremodule|type|immutable|try|let)\\b(?!.*\\bend\\b).*$"
     foldingStopMarker: "^\\s*(?:end)\\b.*$"


### PR DESCRIPTION
which I introduced in https://github.com/JuliaEditorSupport/atom-language-julia/commit/abecd194d0994694eacce65d20beccb774cdcc52. Also, `stagefunction` doesn't exist any more.

It'd be great if someone could try out and merge this soon, because the current behaviour is pretty annoying.

Fixes https://github.com/JunoLab/Atom.jl/issues/62.