### PR TITLE
closed parens are no keywords, even if followed by transpose

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -272,7 +272,7 @@ repository:
       {
         captures:
           "1":
-            name: "keyword.bracket.end.julia"
+            name: "bracket.end.julia"
           "2":
             name: "keyword.operator.transposed-matrix.julia"
         match: "(\\])((?:'|(?:\\.'))*\\.?')"
@@ -280,7 +280,7 @@ repository:
       {
         captures:
           "1":
-            name: "keyword.bracket.end.julia"
+            name: "bracket.end.julia"
           "2":
             name: "keyword.operator.transposed-parens.julia"
         match: "(\\))((?:'|(?:\\.'))*\\.?')"


### PR DESCRIPTION
fixes #82.