### PR TITLE
explicitly add certain super-/subscripts to word definition

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -103,7 +103,7 @@ repository:
   function_call:
     patterns: [
       {
-        begin: "([[:alpha:]_][[:word:]!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\.?\\("
+        begin: "([[:alpha:]_][[:word:]\u207A-\u209C!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\.?\\("
         beginCaptures:
           "1":
             name: "support.function.julia"
@@ -128,7 +128,7 @@ repository:
             name: "entity.name.function.julia"
           "2":
             name: "support.type.julia"
-        match: "([[:alpha:]_][[:word:]!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\((?=.*\\)\\s*=(?![=>]))"
+        match: "([[:alpha:]_][[:word:]\u207A-\u209C!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\((?=.*\\)\\s*=(?![=>]))"
         comment: """
         first group is function name
         Second group is type parameters (e.g. {T<:Number, S})
@@ -151,7 +151,7 @@ repository:
             name: "entity.name.function.julia"
           "4":
             name: "support.type.julia"
-        match: "\\b(function|macro)\\s+(?:[[:alpha:]_][[:word:]!]*(\\.))?([[:alpha:]_][[:word:]!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\("
+        match: "\\b(function|macro)\\s+(?:[[:alpha:]_][[:word:]\u207A-\u209C!]*(\\.))?([[:alpha:]_][[:word:]\u207A-\u209C!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\("
         comment: "similar regex to previous, but with keyword not 1-line syntax"
       }
     ]
@@ -190,7 +190,7 @@ repository:
         name: "keyword.control.using.julia"
       }
       {
-        match: "(@[[:alpha:]_][[:word:]!]*)"
+        match: "(@[[:alpha:]_][[:word:]\u207A-\u209C!]*)"
         name: "support.function.macro.julia"
       }
       {
@@ -224,7 +224,7 @@ repository:
         name: "keyword.operator.update.julia"
       }
       {
-        match: "(?:\\s*::\\s*(?:(?:Union)?\\([^)]*\\)|[[:alpha:]_][[:word:]!\\.]*(?:{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?))(?:\\.\\.\\.)?"
+        match: "(?:\\s*::\\s*(?:(?:Union)?\\([^)]*\\)|[[:alpha:]_][[:word:]\u207A-\u209C!\\.]*(?:{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?))(?:\\.\\.\\.)?"
         name: "support.type.julia"
       }
       {
@@ -267,7 +267,7 @@ repository:
         captures:
           "2":
             name: "keyword.operator.transposed-variable.julia"
-        match: "([[:alpha:]_][[:word:]!]*)(('|(\\.'))*\\.?')"
+        match: "([[:alpha:]_][[:word:]\u207A-\u209C!]*)(('|(\\.'))*\\.?')"
       }
       {
         captures:
@@ -333,7 +333,7 @@ repository:
         ]
       }
       {
-        begin: '^\\s?([[:alpha:]_][[:word:]!]*)?(""")\\s?$'
+        begin: '^\\s?([[:alpha:]_][[:word:]\u207A-\u209C!]*)?(""")\\s?$'
         beginCaptures:
           '1':
             'name': 'support.function.macro.julia'
@@ -438,11 +438,11 @@ repository:
         ]
       }
       {
-        begin: "\\b[[:alpha:]_][[:word:]!]*\""
+        begin: "\\b[[:alpha:]_][[:word:]\u207A-\u209C!]*\""
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
-        end: "\"([[:alpha:]_][[:word:]!]*)?"
+        end: "\"([[:alpha:]_][[:word:]\u207A-\u209C!]*)?"
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.julia"
@@ -517,7 +517,7 @@ repository:
   string_dollar_sign_interpolate:
     patterns: [
       {
-        match: "\\$[[:alpha:]_][[:word:]!]*"
+        match: "\\$[[:alpha:]_][[:word:]\u207A-\u209C!]*"
         name: "variable.interpolation.julia"
       }
       {
@@ -558,7 +558,7 @@ repository:
   symbol:
     patterns: [
       {
-        match: "(?<![a-zA-Z0-9:<]:)(?<=:)[[:alpha:]_][[:word:]!]*"
+        match: "(?<![a-zA-Z0-9:<]:)(?<=:)[[:alpha:]_][[:word:]\u207A-\u209C!]*"
         name: "constant.other.symbol.julia"
         comment: "This is string.quoted.symbol.julia in tpoisot's package"
       }
@@ -573,7 +573,7 @@ repository:
             name: "entity.other.inherited-class.julia"
           "3":
             name: "punctuation.separator.inheritance.julia"
-        match: "(?>!:_)(?:type|immutable)\\s+([[:alpha:]_][[:word:]!]*)(\\s*(<:)\\s*[[:alpha:]_][[:word:]!]*(?:{.*})?)?"
+        match: "(?>!:_)(?:type|immutable)\\s+([[:alpha:]_][[:word:]\u207A-\u209C!]*)(\\s*(<:)\\s*[[:alpha:]_][[:word:]\u207A-\u209C!]*(?:{.*})?)?"
         name: "meta.type.julia"
       }
     ]

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -103,7 +103,7 @@ repository:
   function_call:
     patterns: [
       {
-        begin: "([[:alpha:]_][[:word:]\u207A-\u209C!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\.?\\("
+        begin: "([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\.?\\("
         beginCaptures:
           "1":
             name: "support.function.julia"
@@ -128,7 +128,7 @@ repository:
             name: "entity.name.function.julia"
           "2":
             name: "support.type.julia"
-        match: "([[:alpha:]_][[:word:]\u207A-\u209C!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\((?=.*\\)\\s*=(?![=>]))"
+        match: "([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\((?=.*\\)\\s*=(?![=>]))"
         comment: """
         first group is function name
         Second group is type parameters (e.g. {T<:Number, S})
@@ -151,7 +151,7 @@ repository:
             name: "entity.name.function.julia"
           "4":
             name: "support.type.julia"
-        match: "\\b(function|macro)\\s+(?:[[:alpha:]_][[:word:]\u207A-\u209C!]*(\\.))?([[:alpha:]_][[:word:]\u207A-\u209C!]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\("
+        match: "\\b(function|macro)\\s+(?:[[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*(\\.))?([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?\\("
         comment: "similar regex to previous, but with keyword not 1-line syntax"
       }
     ]
@@ -190,7 +190,7 @@ repository:
         name: "keyword.control.using.julia"
       }
       {
-        match: "(@[[:alpha:]_][[:word:]\u207A-\u209C!]*)"
+        match: "(@[[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)"
         name: "support.function.macro.julia"
       }
       {
@@ -224,7 +224,7 @@ repository:
         name: "keyword.operator.update.julia"
       }
       {
-        match: "(?:\\s*::\\s*(?:(?:Union)?\\([^)]*\\)|[[:alpha:]_][[:word:]\u207A-\u209C!\\.]*(?:{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?))(?:\\.\\.\\.)?"
+        match: "(?:\\s*::\\s*(?:(?:Union)?\\([^)]*\\)|[[:alpha:]_][[:word:]\u207A-\u209C!\u2032\\.]*(?:{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?))(?:\\.\\.\\.)?"
         name: "support.type.julia"
       }
       {
@@ -267,7 +267,7 @@ repository:
         captures:
           "2":
             name: "keyword.operator.transposed-variable.julia"
-        match: "([[:alpha:]_][[:word:]\u207A-\u209C!]*)(('|(\\.'))*\\.?')"
+        match: "([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)(('|(\\.'))*\\.?')"
       }
       {
         captures:
@@ -333,7 +333,7 @@ repository:
         ]
       }
       {
-        begin: '^\\s?([[:alpha:]_][[:word:]\u207A-\u209C!]*)?(""")\\s?$'
+        begin: '^\\s?([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)?(""")\\s?$'
         beginCaptures:
           '1':
             'name': 'support.function.macro.julia'
@@ -438,11 +438,11 @@ repository:
         ]
       }
       {
-        begin: "\\b[[:alpha:]_][[:word:]\u207A-\u209C!]*\""
+        begin: "\\b[[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*\""
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
-        end: "\"([[:alpha:]_][[:word:]\u207A-\u209C!]*)?"
+        end: "\"([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)?"
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.julia"
@@ -517,7 +517,7 @@ repository:
   string_dollar_sign_interpolate:
     patterns: [
       {
-        match: "\\$[[:alpha:]_][[:word:]\u207A-\u209C!]*"
+        match: "\\$[[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*"
         name: "variable.interpolation.julia"
       }
       {
@@ -558,7 +558,7 @@ repository:
   symbol:
     patterns: [
       {
-        match: "(?<![a-zA-Z0-9:<]:)(?<=:)[[:alpha:]_][[:word:]\u207A-\u209C!]*"
+        match: "(?<![a-zA-Z0-9:<]:)(?<=:)[[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*"
         name: "constant.other.symbol.julia"
         comment: "This is string.quoted.symbol.julia in tpoisot's package"
       }
@@ -573,7 +573,7 @@ repository:
             name: "entity.other.inherited-class.julia"
           "3":
             name: "punctuation.separator.inheritance.julia"
-        match: "(?>!:_)(?:type|immutable)\\s+([[:alpha:]_][[:word:]\u207A-\u209C!]*)(\\s*(<:)\\s*[[:alpha:]_][[:word:]\u207A-\u209C!]*(?:{.*})?)?"
+        match: "(?>!:_)(?:type|immutable)\\s+([[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*)(\\s*(<:)\\s*[[:alpha:]_][[:word:]\u207A-\u209C!\u2032]*(?:{.*})?)?"
         name: "meta.type.julia"
       }
     ]

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -1,4 +1,6 @@
 comment: """
+    Reference to the Oniguruma Regex libraray:
+      https://github.com/kkos/oniguruma/blob/master/doc/RE
 
     TODO:
     * Once 0.4 is released, simplify type matches (no explicit 'Union', parens, etc.)

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -12,7 +12,6 @@ describe "Julia grammar", ->
 
   it "tokenizes element-wise operators", ->
     {tokens} = grammar.tokenizeLine("A .* B'")
-    console.log(tokens)
     expect(tokens[0]).toEqual value: "A ", scopes: ["source.julia"]
     expect(tokens[1]).toEqual value: ".*", scopes: ["source.julia", "keyword.operator.arithmetic.julia"]
     expect(tokens[2]).toEqual value: " ", scopes: ["source.julia"]
@@ -21,7 +20,6 @@ describe "Julia grammar", ->
 
   it "tokenizes functions and types", ->
     {tokens} = grammar.tokenizeLine("à_b9!(a::Int64)")
-    console.log(tokens)
     expect(tokens[0]).toEqual value: "à_b9!", scopes: ["source.julia", "support.function.julia"]
     expect(tokens[1]).toEqual value: "(", scopes: ["source.julia"]
     expect(tokens[2]).toEqual value: "a", scopes: ["source.julia"]
@@ -46,7 +44,6 @@ describe "Julia grammar", ->
 
   it "tokenizes functions and (shallowly nested) parameterized types", ->
     {tokens} = grammar.tokenizeLine("x{T <: Dict{Any, Tuple{Int, Int}}}(a::T, b::Union{Int, Set{Any}})")
-    console.log(tokens)
     expect(tokens[0]).toEqual value: "x", scopes: ["source.julia", "support.function.julia"]
     expect(tokens[1]).toEqual value: "{T <: Dict{Any, Tuple{Int, Int}}}", scopes: ["source.julia", "support.type.julia"]
     expect(tokens[2]).toEqual value: "(", scopes: ["source.julia"]
@@ -59,7 +56,6 @@ describe "Julia grammar", ->
 
   it "tokenizes typed arrays and comprehensions", ->
     {tokens} = grammar.tokenizeLine("Int[x for x=y]")
-    console.log(tokens)
     expect(tokens[0]).toEqual value: "Int", scopes: ["source.julia"]
     expect(tokens[1]).toEqual value: "[", scopes: ["source.julia", "meta.array.julia"]
     expect(tokens[2]).toEqual value: "x ", scopes: ["source.julia", "meta.array.julia"]
@@ -83,7 +79,6 @@ describe "Julia grammar", ->
 
   it "tokenizes extension of external methods", ->
     {tokens} = grammar.tokenizeLine("function Base.start(itr::MyItr)")
-    console.log(tokens)
     expect(tokens[0]).toEqual value: "function", scopes: ["source.julia", "keyword.other.julia"]
     expect(tokens[1]).toEqual value: " Base", scopes: ["source.julia"]
     expect(tokens[2]).toEqual value: ".", scopes: ["source.julia", "keyword.operator.dots.julia"]
@@ -253,7 +248,6 @@ describe "Julia grammar", ->
     expect(tokens[6]).toEqual value: ")", scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia"]
     expect(tokens[7]).toEqual value: '"', scopes: ["source.julia", "string.quoted.double.julia", "punctuation.definition.string.end.julia"]
 
-
   it "tokenizes nested interpolated expressions in double strings", ->
     {tokens} = grammar.tokenizeLine('"$((true + length("asdf$asf"))*0x0d) is a number."')
     expect(tokens[0]).toEqual value: '"', scopes: ["source.julia", "string.quoted.double.julia", "punctuation.definition.string.begin.julia"]
@@ -354,3 +348,15 @@ describe "Julia grammar", ->
     expect(tokens[7]).toEqual value: 'in',   scopes:  ["source.julia", "keyword.control.julia"]
     expect(tokens[8]).toEqual value: ' y',   scopes:  ["source.julia"]
     expect(tokens[9]).toEqual value: ')',    scopes:  ["source.julia"]
+
+  it 'tokenizes function definitions with special unicode identifiers', ->
+    {tokens} = grammar.tokenizeLine("f′(xᵢ₊₁) = xᵢ₊₁'")
+    expect(tokens[0]).toEqual value: 'f′',   scopes:  ["source.julia", "entity.name.function.julia"]
+    expect(tokens[1]).toEqual value: '(',    scopes:  ["source.julia"]
+    expect(tokens[2]).toEqual value: 'xᵢ₊₁', scopes:  ["source.julia"]
+    expect(tokens[3]).toEqual value: ')',    scopes:  ["source.julia", "meta.bracket.julia"]
+    expect(tokens[4]).toEqual value: ' ',    scopes:  ["source.julia"]
+    expect(tokens[5]).toEqual value: '=',    scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[6]).toEqual value: ' ',    scopes:  ["source.julia"]
+    expect(tokens[7]).toEqual value: 'xᵢ₊₁', scopes:  ["source.julia"]
+    expect(tokens[8]).toEqual value: "'",    scopes:  ["source.julia", "keyword.operator.transposed-variable.julia"]


### PR DESCRIPTION
Adds the [unicode super- and subscript codeblock](https://en.wikipedia.org/wiki/Unicode_subscripts_and_superscripts) as well as `\prime` (or `′`) as valid identifiers everywhere we only used `[:word:]` so far. I'm not happy with having to special case those, but then again I don't know to determine valid Julia identifiers via Regex without adding an exhaustive list...

Fixes #88.