### PR TITLE
Move julia.console to the source scope

### DIFF
--- a/grammars/julia-console.cson
+++ b/grammars/julia-console.cson
@@ -1,4 +1,4 @@
-scopeName: 'text.julia.console'
+scopeName: 'source.julia.console'
 name: 'Julia Console'
 comment: "Not sure what this will be used for... Maybe if we have a REPL someday"
 patterns: [


### PR DESCRIPTION
Not sure, but it seems like the more appropriate scope.

It fixes the highlighting in the Markdown preview for code blocks like
````
```julia.console
julia> function foo end
function foo end
```
````
I.e. currently they are not highlighted, but with this fix they will be (at least in the preview).