### PR TITLE
Switch docstrings from gfm to language-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Note: if you already have a different version of language-julia plugin installed
 * The [Latex Completions](https://github.com/JunoLab/atom-latex-completions)
   package provides support for unicode characters similarly to the Julia REPL.
 * The [Indent Detective](https://github.com/JunoLab/atom-indent-detective) package will help you keep to the style guidelines when working on Base or packages.
+* Install [language-markdown](https://atom.io/packages/language-markdown) for syntax highlighting in docstrings.
 
 ## Toggling docstrings
 

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -354,14 +354,14 @@ repository:
           '1':
             'name': 'punctuation.definition.string.end.julia'
         name: 'string.docstring.julia'
-        contentName : 'source.gfm'
+        contentName : 'text.md'
         comment: """
         This only matches docstrings that start and end with triple quotes on
         their own line in the void
         """
         patterns: [
           {
-            include: 'source.gfm'
+            include: 'text.md'
           }
           {
             include: '#string_escaped_char'
@@ -496,13 +496,13 @@ repository:
           '2':
             'name': 'keyword.operator.arrow.julia'
         name: 'string.docstring.julia'
-        contentName : 'source.gfm'
+        contentName : 'text.md'
         patterns: [
           {
             include: '#string_escaped_char'
           }
           {
-            include: 'source.gfm'
+            include: 'text.md'
           }
           {
             include: "#string_dollar_sign_interpolate"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -32,7 +32,7 @@ describe "Julia grammar", ->
     expect(tokens[0]).toEqual value: "f", scopes: ["source.julia", "support.function.julia"]
     expect(tokens[1]).toEqual value: "(", scopes: ["source.julia"]
     expect(tokens[2]).toEqual value: "x", scopes: ["source.julia"]
-    expect(tokens[3]).toEqual value: " ", scopes: ["source.julia"]
+    expect(tokens[3]).toEfqual value: " ", scopes: ["source.julia"]
     expect(tokens[4]).toEqual value: "::", scopes: ["source.julia", "keyword.operator.relation.julia"]
     expect(tokens[5]).toEqual value: " ", scopes: ["source.julia"]
     expect(tokens[6]).toEqual value: "Int", scopes: ["source.julia", "support.type.julia"]
@@ -195,7 +195,7 @@ describe "Julia grammar", ->
     foo bar
         \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.nd"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.md"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -32,7 +32,7 @@ describe "Julia grammar", ->
     expect(tokens[0]).toEqual value: "f", scopes: ["source.julia", "support.function.julia"]
     expect(tokens[1]).toEqual value: "(", scopes: ["source.julia"]
     expect(tokens[2]).toEqual value: "x", scopes: ["source.julia"]
-    expect(tokens[3]).toEfqual value: " ", scopes: ["source.julia"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.julia"]
     expect(tokens[4]).toEqual value: "::", scopes: ["source.julia", "keyword.operator.relation.julia"]
     expect(tokens[5]).toEqual value: " ", scopes: ["source.julia"]
     expect(tokens[6]).toEqual value: "Int", scopes: ["source.julia", "support.type.julia"]

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -185,7 +185,7 @@ describe "Julia grammar", ->
     foo bar
     \"\"\"""")
     expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.md"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
@@ -195,7 +195,7 @@ describe "Julia grammar", ->
     foo bar
         \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.nd"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->
@@ -206,7 +206,7 @@ describe "Julia grammar", ->
     \"\"\" foobar
     """)
     expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.md"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
     expect(tokens[4]).toEqual value: " ", scopes: ["source.julia", "string.docstring.julia"]
     expect(tokens[5]).toEqual value: "foobar", scopes: ["source.julia"]
@@ -221,7 +221,7 @@ describe "Julia grammar", ->
     expect(tokens[0]).toEqual value: '@doc', scopes: ["source.julia", "string.docstring.julia", "support.function.macro.julia"]
     expect(tokens[1]).toEqual value: ' ', scopes: ["source.julia", "string.docstring.julia"]
     expect(tokens[2]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[3]).toEqual value: "\ndocstring\n\nfoo bar\n", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
+    expect(tokens[3]).toEqual value: "\ndocstring\n\nfoo bar\n", scopes: ["source.julia", "string.docstring.julia", "text.md"]
     expect(tokens[4]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
     expect(tokens[5]).toEqual value: " ", scopes: ["source.julia", "string.docstring.julia"]
     expect(tokens[6]).toEqual value: "foobar", scopes: ["source.julia"]


### PR DESCRIPTION
Fixes #123, #33.

![image](https://user-images.githubusercontent.com/6735977/32492378-5aa6fd44-c3ba-11e7-9665-2373622b0a9a.png)

This also means that there won't be any highlighting in docstrings if language-markdown ins not installed, so we should probably auto-install language-markdown in Juno.