### PR TITLE
for outer loops

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -67,6 +67,10 @@ repository:
             name: "constant.numeric.julia"
           }
           {
+            match: "\\bfor\\b"
+            name: "keyword.control.julia"
+          }
+          {
             include: "$self"
           }
         ]
@@ -117,6 +121,10 @@ repository:
             name: "keyword.operator.transposed-func.julia"
         patterns: [
           {
+            match: '\\bfor\\b'
+            name: 'keyword.control.julia'
+          }
+          {
             include: "$self"
           }
         ]
@@ -164,7 +172,24 @@ repository:
         name: "keyword.other.julia"
       }
       {
-        match: "\\b(?<![:_])(?:if|else|elseif|while|for(?: outer)?|begin|let|do|try|catch|finally|return|break|continue)\\b"
+        comment: "special case for blocks to support tokenizing outer properly"
+        begin: "\\b(for)\\b"
+        beginCaptures:
+          "0":
+            name: "keyword.control.julia"
+        end: "(?<!,)(\\n)"
+        patterns: [
+          {
+            match: "\\bouter\\b"
+            name: "keyword.other.julia"
+          }
+          {
+            include: '$self'
+          }
+        ]
+      }
+      {
+        match: "\\b(?<![:_])(?:if|else|elseif|while|begin|let|do|try|catch|finally|return|break|continue)\\b"
         name: "keyword.control.julia"
       }
       {

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -164,7 +164,7 @@ repository:
         name: "keyword.other.julia"
       }
       {
-        match: "\\b(?<![:_])(?:if|else|elseif|while|for|begin|let|do|try|catch|finally|return|break|continue)\\b"
+        match: "\\b(?<![:_])(?:if|else|elseif|while|for(?: outer)?|begin|let|do|try|catch|finally|return|break|continue)\\b"
         name: "keyword.control.julia"
       }
       {

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -177,7 +177,7 @@ repository:
         beginCaptures:
           "0":
             name: "keyword.control.julia"
-        end: "(?<!,)(\\n)"
+        end: "(?<!,|\\s)(\\s*\\n)"
         patterns: [
           {
             match: "\\bouter\\b"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -511,10 +511,28 @@ describe "Julia grammar", ->
 
   it 'tokenizes for outer loops', ->
     {tokens} = grammar.tokenizeLine('for outer i = range')
-    expect(tokens[0]).toEqual value: 'for outer', scopes:  ["source.julia", "keyword.control.julia"]
-    expect(tokens[1]).toEqual value: ' i ',       scopes:  ["source.julia"]
-    expect(tokens[2]).toEqual value: '=',         scopes:  ["source.julia", "keyword.operator.update.julia"]
-    expect(tokens[3]).toEqual value: ' range',    scopes:  ["source.julia"]
+    expect(tokens[0]).toEqual value: 'for',       scopes:  ["source.julia", "keyword.control.julia"]
+    expect(tokens[1]).toEqual value: ' ',         scopes:  ["source.julia"]
+    expect(tokens[2]).toEqual value: 'outer',     scopes:  ["source.julia", "keyword.other.julia"]
+    expect(tokens[3]).toEqual value: ' i ',       scopes:  ["source.julia"]
+    expect(tokens[4]).toEqual value: '=',         scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[5]).toEqual value: ' range',    scopes:  ["source.julia"]
+
+  it 'tokenizes for outer loops with multiple iteration variables', ->
+    {tokens} = grammar.tokenizeLine('for outer i = range,\n outer j = range')
+    console.log tokens
+    expect(tokens[0]).toEqual value: 'for',       scopes:  ["source.julia", "keyword.control.julia"]
+    expect(tokens[1]).toEqual value: ' ',         scopes:  ["source.julia"]
+    expect(tokens[2]).toEqual value: 'outer',     scopes:  ["source.julia", "keyword.other.julia"]
+    expect(tokens[3]).toEqual value: ' i ',       scopes:  ["source.julia"]
+    expect(tokens[4]).toEqual value: '=',         scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[5]).toEqual value: ' range',    scopes:  ["source.julia"]
+    expect(tokens[6]).toEqual value: ',',         scopes:  ["source.julia", "meta.bracket.julia"]
+    expect(tokens[7]).toEqual value: '\n ',       scopes:  ["source.julia"]
+    expect(tokens[8]).toEqual value: 'outer',     scopes:  ["source.julia", "keyword.other.julia"]
+    expect(tokens[9]).toEqual value: ' j ',       scopes:  ["source.julia"]
+    expect(tokens[10]).toEqual value: '=',        scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[11]).toEqual value: ' range',   scopes:  ["source.julia"]
 
   it 'does not tokenize outer by itself as a keyword', ->
     {tokens} = grammar.tokenizeLine('outer = foo')

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -519,7 +519,7 @@ describe "Julia grammar", ->
     expect(tokens[5]).toEqual value: ' range',    scopes:  ["source.julia"]
 
   it 'tokenizes for outer loops with multiple iteration variables', ->
-    {tokens} = grammar.tokenizeLine('for outer i = range,\n outer j = range')
+    {tokens} = grammar.tokenizeLine('for outer i = range, \n outer j = range\n outer = 3')
     console.log tokens
     expect(tokens[0]).toEqual value: 'for',       scopes:  ["source.julia", "keyword.control.julia"]
     expect(tokens[1]).toEqual value: ' ',         scopes:  ["source.julia"]
@@ -528,11 +528,16 @@ describe "Julia grammar", ->
     expect(tokens[4]).toEqual value: '=',         scopes:  ["source.julia", "keyword.operator.update.julia"]
     expect(tokens[5]).toEqual value: ' range',    scopes:  ["source.julia"]
     expect(tokens[6]).toEqual value: ',',         scopes:  ["source.julia", "meta.bracket.julia"]
-    expect(tokens[7]).toEqual value: '\n ',       scopes:  ["source.julia"]
+    expect(tokens[7]).toEqual value: ' \n ',      scopes:  ["source.julia"]
     expect(tokens[8]).toEqual value: 'outer',     scopes:  ["source.julia", "keyword.other.julia"]
     expect(tokens[9]).toEqual value: ' j ',       scopes:  ["source.julia"]
     expect(tokens[10]).toEqual value: '=',        scopes:  ["source.julia", "keyword.operator.update.julia"]
     expect(tokens[11]).toEqual value: ' range',   scopes:  ["source.julia"]
+    expect(tokens[12]).toEqual value: '\n',       scopes:  ["source.julia"]
+    expect(tokens[13]).toEqual value: ' outer ',  scopes:  ["source.julia"]
+    expect(tokens[14]).toEqual value: '=',        scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[15]).toEqual value: ' ',        scopes:  ["source.julia"]
+    expect(tokens[16]).toEqual value: '3',        scopes:  ["source.julia", "constant.numeric.julia"]
 
   it 'does not tokenize outer by itself as a keyword', ->
     {tokens} = grammar.tokenizeLine('outer = foo')

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -520,7 +520,6 @@ describe "Julia grammar", ->
 
   it 'tokenizes for outer loops with multiple iteration variables', ->
     {tokens} = grammar.tokenizeLine('for outer i = range, \n outer j = range\n outer = 3')
-    console.log tokens
     expect(tokens[0]).toEqual value: 'for',       scopes:  ["source.julia", "keyword.control.julia"]
     expect(tokens[1]).toEqual value: ' ',         scopes:  ["source.julia"]
     expect(tokens[2]).toEqual value: 'outer',     scopes:  ["source.julia", "keyword.other.julia"]

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -489,13 +489,13 @@ describe "Julia grammar", ->
     expect(tokens[14]).toEqual value: '; i',   scopes:  ["source.julia"]
     expect(tokens[15]).toEqual value: '::',    scopes:  ["source.julia", "keyword.operator.relation.julia"]
     expect(tokens[16]).toEqual value: 'J',     scopes:  ["source.julia", "support.type.julia"]
-    
+
   it "tokenizes dot operators", ->
     {tokens} = grammar.tokenizeLine('x .<= y')
     expect(tokens[0]).toEqual value: 'x ',     scopes:  ["source.julia"]
     expect(tokens[1]).toEqual value: '.<=',    scopes:  ["source.julia", "keyword.operator.relation.julia"]
     expect(tokens[2]).toEqual value: ' y',     scopes:  ["source.julia"]
-  
+
   it "tokenizes type", ->
     {tokens} = grammar.tokenizeLine('T>:Interger')
     expect(tokens[0]).toEqual value: 'T',     scopes:  ["source.julia"]
@@ -508,3 +508,16 @@ describe "Julia grammar", ->
     expect(tokens[1]).toEqual value: ' ',      scopes:  ["source.julia"]
     expect(tokens[2]).toEqual value: '2',      scopes:  ["source.julia", "constant.numeric.julia"]
     expect(tokens[3]).toEqual value: 'img',    scopes:  ["source.julia"]
+
+  it 'tokenizes for outer loops', ->
+    {tokens} = grammar.tokenizeLine('for outer i = range')
+    expect(tokens[0]).toEqual value: 'for outer', scopes:  ["source.julia", "keyword.control.julia"]
+    expect(tokens[1]).toEqual value: ' i ',       scopes:  ["source.julia"]
+    expect(tokens[2]).toEqual value: '=',         scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[3]).toEqual value: ' range',    scopes:  ["source.julia"]
+
+  it 'does not tokenize outer by itself as a keyword', ->
+    {tokens} = grammar.tokenizeLine('outer = foo')
+    expect(tokens[0]).toEqual value: 'outer ', scopes:  ["source.julia"]
+    expect(tokens[1]).toEqual value: '=',      scopes:  ["source.julia", "keyword.operator.update.julia"]
+    expect(tokens[2]).toEqual value: ' foo',   scopes:  ["source.julia"]


### PR DESCRIPTION
Fixes #129.

`outer` is *only* a keyword in `for outer` loops, right?