### PR TITLE
more robust docstring tokenization

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -349,7 +349,7 @@ repository:
             'name': 'support.function.macro.julia'
           '2':
             'name': 'punctuation.definition.string.begin.julia'
-        end: '\\s?^\\s*(""")\\s?'
+        end: '(""")'
         endCaptures:
           '1':
             'name': 'punctuation.definition.string.end.julia'

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -299,6 +299,33 @@ repository:
   string:
     patterns: [
       {
+        begin: '(?:(@doc)\\s((?:doc)?""")|(doc"""))'
+        beginCaptures:
+          '1':
+            'name': 'support.function.macro.julia'
+          '2':
+            'name': 'punctuation.definition.string.begin.julia'
+        end: '(""") ?(->)?'
+        endCaptures:
+          '1':
+            'name': 'punctuation.definition.string.end.julia'
+          '2':
+            'name': 'keyword.operator.arrow.julia'
+        name: 'string.docstring.julia'
+        contentName : 'text.md'
+        patterns: [
+          {
+            include: '#string_escaped_char'
+          }
+          {
+            include: 'text.md'
+          }
+          {
+            include: "#string_dollar_sign_interpolate"
+          }
+        ]
+      }
+      {
         begin: "(i?cxx)(\"\"\")"
         beginCaptures:
           "1":
@@ -476,33 +503,6 @@ repository:
         patterns: [
           {
             include: "#string_escaped_char"
-          }
-          {
-            include: "#string_dollar_sign_interpolate"
-          }
-        ]
-      }
-      {
-        begin: '(@doc) ((?:doc)?""")'
-        beginCaptures:
-          '1':
-            'name': 'support.function.macro.julia'
-          '2':
-            'name': 'punctuation.definition.string.begin.julia'
-        end: '(""") ?(->)?'
-        endCaptures:
-          '1':
-            'name': 'punctuation.definition.string.end.julia'
-          '2':
-            'name': 'keyword.operator.arrow.julia'
-        name: 'string.docstring.julia'
-        contentName : 'text.md'
-        patterns: [
-          {
-            include: '#string_escaped_char'
-          }
-          {
-            include: 'text.md'
           }
           {
             include: "#string_dollar_sign_interpolate"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -187,8 +187,8 @@ describe "Julia grammar", ->
     foo bar
     \"\"\"""")
     expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.md"]
-    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar\n", scopes: ["source.julia", "string.docstring.julia", "text.md"]
+    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
@@ -197,8 +197,18 @@ describe "Julia grammar", ->
     foo bar
         \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.md"]
-    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar\n    ", scopes: ["source.julia", "string.docstring.julia", "text.md"]
+    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+
+  it "tokenizes docstrings with no linebreak before the ending triple-quotes", ->
+    {tokens} = grammar.tokenizeLine("""\"\"\"
+    docstring
+
+    foo bar \"\"\"""")
+    expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar ", scopes: ["source.julia", "string.docstring.julia", "text.md"]
+    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
@@ -208,10 +218,9 @@ describe "Julia grammar", ->
     \"\"\" foobar
     """)
     expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "text.md"]
-    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
-    expect(tokens[4]).toEqual value: " ", scopes: ["source.julia", "string.docstring.julia"]
-    expect(tokens[5]).toEqual value: "foobar", scopes: ["source.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar\n", scopes: ["source.julia", "string.docstring.julia", "text.md"]
+    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[3]).toEqual value: " foobar", scopes: ["source.julia"]
 
   it "tokenizes @doc docstrings that have extra content after ending tripe quote", ->
     {tokens} = grammar.tokenizeLine("""@doc \"\"\"
@@ -489,13 +498,13 @@ describe "Julia grammar", ->
     expect(tokens[14]).toEqual value: '; i',   scopes:  ["source.julia"]
     expect(tokens[15]).toEqual value: '::',    scopes:  ["source.julia", "keyword.operator.relation.julia"]
     expect(tokens[16]).toEqual value: 'J',     scopes:  ["source.julia", "support.type.julia"]
-    
+
   it "tokenizes dot operators", ->
     {tokens} = grammar.tokenizeLine('x .<= y')
     expect(tokens[0]).toEqual value: 'x ',     scopes:  ["source.julia"]
     expect(tokens[1]).toEqual value: '.<=',    scopes:  ["source.julia", "keyword.operator.relation.julia"]
     expect(tokens[2]).toEqual value: ' y',     scopes:  ["source.julia"]
-  
+
   it "tokenizes type", ->
     {tokens} = grammar.tokenizeLine('T>:Interger')
     expect(tokens[0]).toEqual value: 'T',     scopes:  ["source.julia"]


### PR DESCRIPTION
fixes https://github.com/JuliaEditorSupport/atom-language-julia/issues/115, https://github.com/JuliaEditorSupport/julia-vscode/issues/256, and https://github.com/JuliaEditorSupport/atom-language-julia/issues/78 (at least that works now, probably not fixed by this exact PR).