### PR TITLE
Remove duplicate ".source.julia" key

### DIFF
--- a/snippets/language-julia.cson
+++ b/snippets/language-julia.cson
@@ -7,7 +7,6 @@
       $3
       """ ->
     '''
-".source.julia":
   "Documented function":
     prefix: "fxd"
     body: '''


### PR DESCRIPTION
This should hopefully fix [issue 146](https://github.com/JuliaEditorSupport/atom-language-julia/issues/146).