### PR TITLE
Remove duplicate entry `.source.julia`

### DIFF
--- a/snippets/language-julia.cson
+++ b/snippets/language-julia.cson
@@ -7,7 +7,6 @@
       $3
       """ ->
     '''
-".source.julia":
   "Documented function":
     prefix: "fxd"
     body: '''


### PR DESCRIPTION
I think the line 10 in the old file was forgotten there. The old file gives an error message on the start-up.