### PR TITLE
Support nested block comments

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -90,6 +90,19 @@ repository:
     ]
   comment:
     patterns: [
+      {include: '#comment_block'}
+      {
+        begin: "#"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.comment.julia"
+        end: "\\n"
+        # match: "(?<!\\$)(#)(?!\\{).*$\\n?"
+        name: "comment.line.number-sign.julia"
+      }
+    ]
+  comment_block:
+    patterns: [
       {
         begin: "#="
         beginCaptures:
@@ -100,15 +113,9 @@ repository:
           "0":
             name: "punctuation.definition.comment.end.julia"
         name: "comment.block.number-sign-equals.julia"
-      }
-      {
-        begin: "#"
-        beginCaptures:
-          "0":
-            name: "punctuation.definition.comment.julia"
-        end: "\\n"
-        # match: "(?<!\\$)(#)(?!\\{).*$\\n?"
-        name: "comment.line.number-sign.julia"
+        patterns: [
+          {include: '#comment_block'}
+        ]
       }
     ]
   function_call:

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -376,6 +376,16 @@ describe "Julia grammar", ->
     expect(tokens[0]).toEqual value: '#', scopes: ["source.julia", "comment.line.number-sign.julia", "punctuation.definition.comment.julia"]
     expect(tokens[1]).toEqual value: ' This is a comment', scopes: ["source.julia", "comment.line.number-sign.julia"]
 
+  it "tokenizes block comments", ->
+    {tokens} = grammar.tokenizeLine('#= begin #= begin end =# end =#')
+    expect(tokens[0]).toEqual value: "#=", scopes: ["source.julia", "comment.block.number-sign-equals.julia", "punctuation.definition.comment.begin.julia"]
+    expect(tokens[1]).toEqual value: " begin ", scopes: ["source.julia", "comment.block.number-sign-equals.julia"]
+    expect(tokens[2]).toEqual value: "#=", scopes: ["source.julia", "comment.block.number-sign-equals.julia", "comment.block.number-sign-equals.julia", "punctuation.definition.comment.begin.julia"]
+    expect(tokens[3]).toEqual value: " begin end ", scopes: ["source.julia", "comment.block.number-sign-equals.julia", "comment.block.number-sign-equals.julia"]
+    expect(tokens[4]).toEqual value: "=#", scopes: ["source.julia", "comment.block.number-sign-equals.julia", "comment.block.number-sign-equals.julia", "punctuation.definition.comment.end.julia"]
+    expect(tokens[5]).toEqual value: " end ", scopes: ["source.julia", "comment.block.number-sign-equals.julia"]
+    expect(tokens[6]).toEqual value: "=#", scopes: ["source.julia", "comment.block.number-sign-equals.julia", "punctuation.definition.comment.end.julia"]
+
   it "tokenizes the pair assignment operator", ->
     {tokens} = grammar.tokenizeLine('Dict(x => x for x in y)')
     expect(tokens[0]).toEqual value: 'Dict', scopes:  ["source.julia", "support.function.julia"]


### PR DESCRIPTION
Block comments [can be nested](https://docs.julialang.org/en/v0.6.1/stdlib/punctuation/).

Turns this:
<img width="503" alt="image" src="https://user-images.githubusercontent.com/15164633/43378939-cf35c2fa-9397-11e8-99f1-e35950c9e721.png">

Into this:
<img width="531" alt="image" src="https://user-images.githubusercontent.com/15164633/43378954-dab46820-9397-11e8-8528-e6911c860818.png">

Code from here: https://learnxinyminutes.com/docs/julia/