### PR TITLE
Add `primitive type` to keywords

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -182,7 +182,7 @@ repository:
   keyword:
     patterns: [
       {
-        match: "\\b(?<![:_\\.])(?:function|@generated|type|immutable|mutable|struct|macro|quote|abstract|bitstype|typealias|module|baremodule|new|where)\\b"
+        match: "\\b(?<![:_\\.])(?:function|@generated|type|immutable|mutable|struct|macro|quote|abstract|primitive type|bitstype|typealias|module|baremodule|new|where)\\b"
         name: "keyword.other.julia"
       }
       {


### PR DESCRIPTION
I'm not sure whether this will work properly but it naively seemed more correct than just adding `primitive`, as that alone is not a keyword. I'm hoping that since it ends in `type`, it will be properly recognized by the folding marker and autoindent. I don't use Atom so I haven't tested locally; I noticed this because GitHub uses this repo for the Julia definitions in the GitHub UI.