### PR TITLE
Highlight `const` etc as keywords

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -212,7 +212,7 @@ repository:
       }
       {
         match: "\\b(?<![:_])(?:global|local|const)\\b"
-        name: "storage.modifier.julia"
+        name: "keyword.storage.modifier.julia"
       }
       {
         match: "\\b(?<![:_])(?:export)\\b"

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -205,7 +205,7 @@ repository:
       }
       {
         match: "\\b(?<![:_])(?:global|local|const)\\b"
-        name: "storage.modifier.variable.julia"
+        name: "storage.modifier.julia"
       }
       {
         match: "\\b(?<![:_])(?:export)\\b"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -101,6 +101,11 @@ describe "Julia grammar", ->
     expect(tokens[28]).toEqual value: "X.Y.Z", scopes: ["source.julia", "support.type.julia"]
     expect(tokens[29]).toEqual value: ")", scopes: ["source.julia", "meta.bracket.julia"]
 
+  it "tokenizes `const` as a keyword", ->
+    {tokens} = grammar.tokenizeLine("const Foo")
+    expect(tokens[0]).toEqual value: "const", scopes: ["source.julia", "keyword.storage.modifier.julia"]
+    expect(tokens[1]).toEqual value: " Foo", scopes: ["source.julia"]
+
   it "tokenizes functions and (shallowly nested) parameterized types", ->
     {tokens} = grammar.tokenizeLine("x{T <: Dict{Any, Tuple{Int, Int}}}(a::T, b::Union{Int, Set{Any}})")
     expect(tokens[0]).toEqual value: "x", scopes: ["source.julia", "support.function.julia"]


### PR DESCRIPTION
Should be squashed on merge.
Fixes #159. 