### PR TITLE
fix `@macro "string" begin` indentation

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -13,8 +13,6 @@ fileTypes: [
   "jl"
 ]
 firstLineMatch: "^#!.*\\bjulia\\s*$"
-foldingStartMarker: "^\\s*(?:if|while|for|begin|function|macro|module|baremodule|type|immutable|struct|try|let)\\b(?!.*\\bend\\b).*$"
-foldingStopMarker: "^\\s*(?:end)\\b.*$"
 name: "Julia"
 patterns: [
   {

--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -2,9 +2,7 @@
   editor:
     tabLength: 4
     commentStart: "# "
-".source.julia:not(.string)":
-  editor:
-    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*\\b(if|while|for|function|macro|immutable|struct|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
+    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)([\\w\\s]*|\\s+\".*\"\\s+)\\b(if|while|for|function|macro|immutable|struct|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
     foldingStartMarker: "^\\s*(?:if|while|for|begin|function|macro|module|baremodule|type|immutable|struct|try|let)\\b(?!.*\\bend\\b).*$"
     foldingStopMarker: "^\\s*(?:end)\\b.*$"


### PR DESCRIPTION
Fixes https://github.com/JuliaEditorSupport/atom-language-julia/issues/37 again.

cc @mkborregaard: Would be cool if you could try this for a bit since I'm not super confident this doesn't break anything (and this change also is basically untestable).