### PR TITLE
remove legacy syntax highlighting

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -180,7 +180,7 @@ repository:
   keyword:
     patterns: [
       {
-        match: "\\b(?<![:_\\.])(?:function|@generated|type|immutable|mutable\\s+struct|struct|macro|quote|abstract\\s+type|primitive\\s+type|bitstype|typealias|module|baremodule|new|where)\\b"
+        match: "\\b(?<![:_\\.])(?:function|mutable\\s+struct|struct|macro|quote|abstract\\s+type|primitive\\s+type|module|baremodule|new|where)\\b"
         name: "keyword.other.julia"
       }
       {
@@ -219,10 +219,6 @@ repository:
       {
         match: "\\b(?<![:_])(?:import)\\b"
         name: "keyword.control.import.julia"
-      }
-      {
-        match: "\\b(?<![:_])(?:importall)\\b"
-        name: "keyword.control.importall.julia"
       }
       {
         match: "\\b(?<![:_])(?:using)\\b"
@@ -605,7 +601,7 @@ repository:
             name: "entity.other.inherited-class.julia"
           "3":
             name: "punctuation.separator.inheritance.julia"
-        match: "(?>!:_)(?:type|immutable|struct)\\s+([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)(\\s*(<:)\\s*[[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*(?:{.*})?)?"
+        match: "(?>!:_)(?:struct|mutable\\s+struct|abstract\\s+type|primitive\\s+type)\\s+([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)(\\s*(<:)\\s*[[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*(?:{.*})?)?"
         name: "meta.type.julia"
       }
     ]

--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -2,7 +2,7 @@
   editor:
     tabLength: 4
     commentStart: "# "
-    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)([\\w\\s]*|\\s+\".*\"\\s+)\\b(if|while|for|function|macro|immutable|struct|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
+    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*\\b(if|while|for|function|macro|immutable|mutable\\s+struct|struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
     foldEndPattern: '^\\s*\\]|^\\s*\\)'
 

--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -2,7 +2,7 @@
   editor:
     tabLength: 4
     commentStart: "# "
-    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*\\b(if|while|for|function|macro|immutable|mutable\\s+struct|struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
+    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)([\\w\\s]*|\\s+\".*\"\\s+)\\b(if|while|for|function|macro|immutable|mutable\\s+struct|struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
     foldEndPattern: '^\\s*\\]|^\\s*\\)'
 

--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -2,7 +2,7 @@
   editor:
     tabLength: 4
     commentStart: "# "
-    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)([\\w\\s]*|\\s+\".*\"\\s+)\\b(if|while|for|function|macro|immutable|mutable\\s+struct|struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
+    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)([\\w\\s]*|\\s+\".*\"\\s+)\\b(if|while|for|function|macro|mutable\\s+struct|struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
     foldEndPattern: '^\\s*\\]|^\\s*\\)'
 

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -190,13 +190,6 @@ describe "Julia grammar", ->
     expect(tokens[2]).toEqual value: ".", scopes: ["source.julia", "keyword.operator.dots.julia"]
     expect(tokens[3]).toEqual value: "Test", scopes: ["source.julia"]
 
-  it "tokenizes importall statements", ->
-    {tokens} = grammar.tokenizeLine("importall Base.Test")
-    expect(tokens[0]).toEqual value: "importall", scopes: ["source.julia", "keyword.control.importall.julia"]
-    expect(tokens[1]).toEqual value: " Base", scopes: ["source.julia"]
-    expect(tokens[2]).toEqual value: ".", scopes: ["source.julia", "keyword.operator.dots.julia"]
-    expect(tokens[3]).toEqual value: "Test", scopes: ["source.julia"]
-
   it "tokenizes export statements", ->
     {tokens} = grammar.tokenizeLine("export my_awesome_function")
     expect(tokens[0]).toEqual value: "export", scopes: ["source.julia", "keyword.control.export.julia"]


### PR DESCRIPTION
for Julia versions < 0.7