### PR TITLE
Add foldEndPattern to settings to improve folding and Hydrogen selections

### DIFF
--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -2,6 +2,7 @@
   editor:
     tabLength: 4
     commentStart: "# "
+    foldEndPattern: '^\\s*\\]|^\\s*\\)'
 ".source.julia:not(.string)":
   editor:
     increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*\\b(if|while|for|function|macro|immutable|struct|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"


### PR DESCRIPTION
(I sent similar PRs to the `language-python` https://github.com/atom/language-python/pull/274, and MagicPython https://github.com/MagicStack/MagicPython/pull/161 syntax highlighters)

Note: I don't understand Julia's syntax too well, so the exact regular expression used in `foldEndPattern` is subject to debate. Regardless, this addition would serve Hydrogen+IJulia users.

### Description of the Change

Add a value for `foldEndPattern` in the package settings. The regex used is `^\\s*\\]|^\\s*\\)` in order to fold the end of arrays and functions. It folds the entire logical syntax item instead of leaving the ending character on a separate line. It also improves the use of [Hydrogen](https://atom.io/packages/Hydrogen) when the ending `)`, or `]` is on a separate line and not indented.

Many other Atom language grammars have a `foldEndPattern`; the regex used in this PR is taken from [`language-javascript`](https://github.com/atom/language-javascript/blob/df7a049ec5b6e866b1686c561ba8d8bb7c0de0c5/settings/language-javascript.cson#L5) because of the similarity in syntax used for data structures.

### Benefits

1. Improve fold behavior by including the ending character (see screenshots below)

**Expanded**:
![image](https://user-images.githubusercontent.com/15164633/45452060-ef487980-b6aa-11e8-87d9-2e8badf49a02.png)

**Current fold behavior**:
![image](https://user-images.githubusercontent.com/15164633/45452094-07b89400-b6ab-11e8-9b2e-d34a4d041222.png)

**New fold behavior**:
![image](https://user-images.githubusercontent.com/15164633/45452071-f7a0b480-b6aa-11e8-88fc-8af9eb28351c.png)

2. This would also improve behavior with the [Hydrogen](https://atom.io/packages/Hydrogen) package, as that uses Atom's fold regions to decide what block of code to send to the Jupyter kernel. (Currently you have to manually select the entire block in these cases).

**Current Hydrogen behavior with ending character on separate line**:
![peek 2018-09-12 16-31](https://user-images.githubusercontent.com/15164633/45451978-ac86a180-b6aa-11e8-8b35-57a952bdaa21.gif)

**New Hydrogen behavior with ending character on separate line**:
![peek 2018-09-12 16-32](https://user-images.githubusercontent.com/15164633/45451953-9d9fef00-b6aa-11e8-90f3-7f4a4c73ad11.gif)

### Applicable Issues

These issues refer to Python, but the same behavior exists when using IJulia.

- https://github.com/nteract/hydrogen/issues/724
- https://github.com/nteract/hydrogen/issues/155
