### PR TITLE
Add PyCall.jl syntax highlighting.

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -399,6 +399,50 @@ repository:
         ]
       }
       {
+        begin: "(py)(\"\"\")"
+        beginCaptures:
+          "1":
+            name: "support.function.macro.julia"
+          "2":
+            name: "punctuation.definition.string.begin.julia"
+        end: "\"\"\""
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        name: 'embed.python.julia'
+        contentName: 'source.python'
+        patterns: [
+          {
+            include: 'source.python'
+          }
+          {
+            include: '#string_dollar_sign_interpolate'
+          }
+        ]
+      }
+      {
+        begin: "(py)(\")"
+        beginCaptures:
+          "1":
+            name: "support.function.macro.julia"
+          "2":
+            name: "punctuation.definition.string.begin.julia"
+        end: "\""
+        name: 'embed.python.julia'
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        contentName: 'source.python'
+        patterns: [
+          {
+            include: 'source.python'
+          }
+          {
+            include: '#string_dollar_sign_interpolate'
+          }
+        ]
+      }
+      {
         begin: '^\\s?([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?(""")\\s?$'
         beginCaptures:
           '1':

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -401,6 +401,24 @@ describe "Julia grammar", ->
     expect(tokens[2]).toEqual value: 'std::string', scopes: ["source.julia", "embed.cxx.julia", "source.cpp"]
     expect(tokens[3]).toEqual value: '"', scopes: ["source.julia", "embed.cxx.julia", "punctuation.definition.string.end.julia"]
 
+  it "tokenizes PyCall.jl multiline string macros", ->
+    tokens = grammar.tokenizeLines('''
+    py"""
+    import numpy as np
+    """
+    ''')
+    expect(tokens[0][0]).toEqual value: 'py', scopes: ["source.julia", "embed.python.julia", "support.function.macro.julia"]
+    expect(tokens[0][1]).toEqual value: '"""', scopes: ["source.julia", "embed.python.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1][0]).toEqual value: 'import numpy as np', scopes: ["source.julia", "embed.python.julia", "source.python"]
+    expect(tokens[2][0]).toEqual value: '"""', scopes: ["source.julia", "embed.python.julia", "punctuation.definition.string.end.julia"]
+
+  it "tokenizes PyCall.jl single lin string macros", ->
+    {tokens} = grammar.tokenizeLine('py"np.array()"')
+    expect(tokens[0]).toEqual value: 'py', scopes: ["source.julia", "embed.python.julia", "support.function.macro.julia"]
+    expect(tokens[1]).toEqual value: '"', scopes: ["source.julia", "embed.python.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: 'np.array()', scopes: ["source.julia", "embed.python.julia", "source.python"]
+    expect(tokens[3]).toEqual value: '"', scopes: ["source.julia", "embed.python.julia", "punctuation.definition.string.end.julia"]
+
   it "tokenizes symbols of `keyword.other`s", ->
     {tokens} = grammar.tokenizeLine(':type')
     expect(tokens[0]).toEqual value: ':type', scopes: ["source.julia", "constant.other.symbol.julia"]


### PR DESCRIPTION
This request implements syntax highlighting for PyCall.jl macros that is similar to that which was already implemented for Cxx.jl. I've found this particular feature helpful, hopefully others will too :-).