### PR TITLE
Better parsing of triple quoted strings

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -466,7 +466,7 @@ repository:
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
-        end: '(?<!\\)"'
+        end: '"'
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.julia"
@@ -500,15 +500,17 @@ repository:
         ]
       }
       {
-        begin: "\\b([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)\"\"\""
+        begin: "(?<!\")\\b([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)\"\"\""
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
           "1":
-            name: "support.funtion.macro.julia"
-        end: "\"\"\"([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
+            name: "support.function.macro.julia"
+        end: "(\"\"\")([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
         endCaptures:
-          "0":
+          "1":
+            name: "punctuation.definition.string.end.julia"
+          "2":
             name: "punctuation.definition.string.end.julia"
         name: "string.quoted.other.julia"
         patterns: [
@@ -518,15 +520,17 @@ repository:
         ]
       },
       {
-        begin: "\\b([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)\"(?!\")"
+        begin: "(?<!\")\\b([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)\"(?!\")"
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
           "1":
-            name: "support.funtion.macro.julia"
-        end: "(?<!\\\\)\"([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
+            name: "support.function.macro.julia"
+        end: "(\")([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
         endCaptures:
-          "0":
+          "1":
+            name: "punctuation.definition.string.end.julia"
+          "2":
             name: "punctuation.definition.string.end.julia"
         name: "string.quoted.other.julia"
         patterns: [

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -440,7 +440,7 @@ repository:
         ]
       }
       {
-        begin: '"""'
+        begin: '(?<![[:word:]\u207A-\u209C!\u2032\u2207])"""'
         beginCaptures:
           "0":
             name: "punctuation.definition.string.multiline.begin.julia"
@@ -462,11 +462,11 @@ repository:
       }
       {
         name: "string.quoted.double.julia"
-        begin: '"'
+        begin: '(?<![[:word:]\u207A-\u209C!\u2032\u2207])"(?!"")'
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
-        end: '"'
+        end: '(?<!\\)"'
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.julia"
@@ -500,11 +500,31 @@ repository:
         ]
       }
       {
-        begin: "\\b[[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*\""
+        begin: "\\b([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)\"\"\""
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.julia"
-        end: "\"([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
+          "1":
+            name: "support.funtion.macro.julia"
+        end: "\"\"\"([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        name: "string.quoted.other.julia"
+        patterns: [
+          {
+            include: "#string_escaped_char"
+          }
+        ]
+      },
+      {
+        begin: "\\b([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)\"(?!\")"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.julia"
+          "1":
+            name: "support.funtion.macro.julia"
+        end: "(?<!\\\\)\"([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?"
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.julia"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -206,13 +206,27 @@ describe "Julia grammar", ->
     expect(tokens[2]).toEqual value: "\"", scopes: ["source.julia", "string.regexp.julia", "punctuation.definition.string.regexp.end.julia"]
     expect(tokens[3]).toEqual value: "im", scopes: ["source.julia", "string.regexp.julia", "keyword.other.option-toggle.regexp.julia"]
 
+  it 'tokenizes macro strings with triple quotes', ->
+    {tokens} = grammar.tokenizeLine('ab"""xyz"""')
+    expect(tokens[0]).toEqual value: "ab", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia", "support.function.macro.julia"]
+    expect(tokens[1]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: "xyz", scopes: ["source.julia", "string.quoted.other.julia"]
+    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.end.julia"]
+
+  it 'tokenizes tripple quotes', ->
+    {tokens} = grammar.tokenizeLine('"""xyz"""')
+    expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.quoted.triple.double.julia", "punctuation.definition.string.multiline.begin.julia"]
+    expect(tokens[1]).toEqual value: "xyz", scopes: ["source.julia", "string.quoted.triple.double.julia"]
+    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.quoted.triple.double.julia", "punctuation.definition.string.multiline.end.julia"]
+
   it 'tokenizes macro strings with escaped chars', ->
     {tokens} = grammar.tokenizeLine('m"α\\u1234\\\\"')
-    expect(tokens[0]).toEqual value: "m\"", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "α", scopes: ["source.julia", "string.quoted.other.julia"]
-    expect(tokens[2]).toEqual value: "\\u1234", scopes: ["source.julia", "string.quoted.other.julia", "constant.character.escape.julia"]
-    expect(tokens[3]).toEqual value: "\\\\", scopes: ["source.julia", "string.quoted.other.julia", "constant.character.escape.julia"]
-    expect(tokens[4]).toEqual value: "\"", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[0]).toEqual value: "m", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia", "support.function.macro.julia"]
+    expect(tokens[1]).toEqual value: "\"", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: "α", scopes: ["source.julia", "string.quoted.other.julia"]
+    expect(tokens[3]).toEqual value: "\\u1234", scopes: ["source.julia", "string.quoted.other.julia", "constant.character.escape.julia"]
+    expect(tokens[4]).toEqual value: "\\\\", scopes: ["source.julia", "string.quoted.other.julia", "constant.character.escape.julia"]
+    expect(tokens[5]).toEqual value: "\"", scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes docstrings", ->
     {tokens} = grammar.tokenizeLine("@doc doc\"\"\" xx *x* \"\"\" ->")
@@ -379,9 +393,11 @@ describe "Julia grammar", ->
 
   it "tokenizes custom string literals", ->
     {tokens} = grammar.tokenizeLine('àb9!"asdf"_a9Ñ')
-    expect(tokens[0]).toEqual value: 'àb9!"', scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "asdf", scopes: ["source.julia", "string.quoted.other.julia"]
-    expect(tokens[2]).toEqual value: '"_a9Ñ', scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[0]).toEqual value: 'àb9!', scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia", "support.function.macro.julia"]
+    expect(tokens[1]).toEqual value: '"', scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: "asdf", scopes: ["source.julia", "string.quoted.other.julia"]
+    expect(tokens[3]).toEqual value: '"', scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.end.julia"]
+    expect(tokens[4]).toEqual value: '_a9Ñ', scopes: ["source.julia", "string.quoted.other.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes Cxx.jl multiline string macros", ->
     tokens = grammar.tokenizeLines('''


### PR DESCRIPTION
This change ensures triple quoted  standard and non-stadard string literals are parsed properly. Before this change """bla bla bla""" would be parsed as three separate string literals: [""]["bla bla bla"][""] rather than as one string literal ["""bla bla bla"""].

This also changes non-standard string literals, highlighting the prefix with the support.function.macro color.

I ran into this problem while looking to create a small vscode plugin (and the vscode language support just copies over the cson from this repository). The plugin's goal is to allow the injection of other languages within Julia (e.g. to properly parse mat"x + 1" as matlab code and py"x + 1" as python code, etc...). Without this change it is quite hard to avoid parsing errors when injecting the grammar (because it is hard to find the triple quoted sections, as they are labeled as three different, ungrouped entities).

I have copied this over very carefully from my changes in visual studio code (which I have verified work there). However, I haven't tested this in Atom: apologies for that; at the moment I don't haver it installed on my machine. 