### PR TITLE
Limit docstring classification

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -487,7 +487,7 @@ repository:
         ]
       }
       {
-        begin: '^\\s?([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)?(""")\\s?$'
+        begin: '^\\s?(doc|raw)?(""")\\s?$'
         beginCaptures:
           '1':
             'name': 'support.function.macro.julia'


### PR DESCRIPTION
Before, any custom string was counted as a docstring when present as the first non-whitespace token on a line. After, only `raw` and `doc` count as docstrings, allowing for quoted code (e.g. `py"""` from PyCall or `R"""` from RCall) to properly highlight with an appropriate extension.

Are there any other docstring prefixes that would make sense?

This will hopefully address the problems raised in [this issue](https://github.com/haberdashPI/vscode-python-in-julia/issues/1). It's also relevant to issues using [this](https://github.com/haberdashPI/vscode-matlab-in-julia) extension and [this one](https://github.com/haberdashPI/vscode-R-in-julia).