### PR TITLE
Add highlighting for multiline Markdown strings

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -553,6 +553,28 @@ repository:
         ]
       }
       {
+        begin: "(md)(\")"
+        beginCaptures:
+          "1":
+            name: "support.function.macro.julia"
+          "2":
+            name: "punctuation.definition.string.begin.julia"
+        end: "\""
+        name: 'embed.markdown.julia'
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        contentName: 'source.gfm'
+        patterns: [
+          {
+            include: 'source.gfm'
+          }
+          {
+            include: '#string_dollar_sign_interpolate'
+          }
+        ]
+      }
+      {
         begin: '^\\s?(doc|raw)?(""")\\s?$'
         beginCaptures:
           '1':

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -531,6 +531,28 @@ repository:
         ]
       }
       {
+        begin: "(md)(\"\"\")"
+        beginCaptures:
+          "1":
+            name: "support.function.macro.julia"
+          "2":
+            name: "punctuation.definition.string.begin.julia"
+        end: "\"\"\""
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.julia"
+        name: 'embed.markdown.julia'
+        contentName: 'source.gfm'
+        patterns: [
+          {
+            include: 'source.gfm'
+          }
+          {
+            include: '#string_dollar_sign_interpolate'
+          }
+        ]
+      }
+      {
         begin: '^\\s?(doc|raw)?(""")\\s?$'
         beginCaptures:
           '1':

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -507,6 +507,13 @@ describe "Julia grammar", ->
     expect(tokens[1][0]).toEqual value: '# hello world', scopes: ["source.julia", "embed.markdown.julia", "source.gfm"]
     expect(tokens[2][0]).toEqual value: '"""', scopes: ["source.julia", "embed.markdown.julia", "punctuation.definition.string.end.julia"]
 
+  it "tokenizes Markdown single line string macros", ->
+    {tokens} = grammar.tokenizeLine('md"hello *world*"')
+    expect(tokens[0]).toEqual value: 'md', scopes: ["source.julia", "embed.markdown.julia", "support.function.macro.julia"]
+    expect(tokens[1]).toEqual value: '"', scopes: ["source.julia", "embed.markdown.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: 'hello *world*', scopes: ["source.julia", "embed.markdown.julia", "source.gfm"]
+    expect(tokens[3]).toEqual value: '"', scopes: ["source.julia", "embed.markdown.julia", "punctuation.definition.string.end.julia"]
+
   it "tokenizes symbols of `keyword.other`s", ->
     {tokens} = grammar.tokenizeLine(':type')
     expect(tokens[0]).toEqual value: ':type', scopes: ["source.julia", "constant.other.symbol.julia"]

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -496,6 +496,17 @@ describe "Julia grammar", ->
     expect(tokens[2]).toEqual value: 'new Promise()', scopes: ["source.julia", "embed.js.julia", "source.js"]
     expect(tokens[3]).toEqual value: '"', scopes: ["source.julia", "embed.js.julia", "punctuation.definition.string.end.julia"]
 
+  it "tokenizes Markdown multiline string macros", ->
+    tokens = grammar.tokenizeLines('''
+    md"""
+    # hello world
+    """
+    ''')
+    expect(tokens[0][0]).toEqual value: 'md', scopes: ["source.julia", "embed.markdown.julia", "support.function.macro.julia"]
+    expect(tokens[0][1]).toEqual value: '"""', scopes: ["source.julia", "embed.markdown.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1][0]).toEqual value: '# hello world', scopes: ["source.julia", "embed.markdown.julia", "source.gfm"]
+    expect(tokens[2][0]).toEqual value: '"""', scopes: ["source.julia", "embed.markdown.julia", "punctuation.definition.string.end.julia"]
+
   it "tokenizes symbols of `keyword.other`s", ->
     {tokens} = grammar.tokenizeLine(':type')
     expect(tokens[0]).toEqual value: ':type', scopes: ["source.julia", "constant.other.symbol.julia"]


### PR DESCRIPTION
It's similar to code recently added for R and Python string literals. Markdown support is useful for code like [this](https://github.com/JuliaLang/Pkg.jl/blob/7ca3e387919bbd87c23823cb593f8f9afda16766/src/REPL/command_declarations.jl#L13-L20).