### PR TITLE
actually use language-markdown syntax

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -151,17 +151,18 @@ repository:
           "2":
             name: "support.type.julia"
         match: "([[:alpha:]_\u2207][[:word:]\u207A-\u209C!\u2032\u2207]*)({(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})?(?=\\(.*\\)(::[^\\s]+)?(\\s*\\bwhere\\b\\s+.+?)?\\s*?=(?![=>]))"
-        comment: """
-        first group is function name
-        Second group is type parameters (e.g. {T<:Number, S})
-        Then open parens
-        Then a lookahead ensures that we are followed by:
-          - anything (function argumnets)
-          - 0 or more spaces
-          - Finally an equal sign
-        Negative lookahead ensures we don't have another equal sign (not `==`)
-        """
-        comment: "This is different from the one in tpoisot's package"
+        comment:
+          """
+          first group is function name
+          Second group is type parameters (e.g. {T<:Number, S})
+          Then open parens
+          Then a lookahead ensures that we are followed by:
+            - anything (function argumnets)
+            - 0 or more spaces
+            - Finally an equal sign
+          Negative lookahead ensures we don't have another equal sign (not `==`)
+          """
+        # NOTE: This is different from the one in tpoisot's package
       }
       {
         captures:
@@ -632,7 +633,7 @@ repository:
             name: "punctuation.definition.string.multiline.end.julia"
         name: "string.quoted.triple.double.julia"
         comment: "multi-line string with triple double quotes"
-        comment: "TODO: decide on a name for this scope"
+        # TODO: decide on a name for this scope
         patterns: [
           {
             include: "#string_escaped_char"

--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -545,6 +545,9 @@ repository:
         contentName: 'source.gfm'
         patterns: [
           {
+            include: 'text.md'
+          }
+          {
             include: 'source.gfm'
           }
           {
@@ -566,6 +569,9 @@ repository:
             name: "punctuation.definition.string.end.julia"
         contentName: 'source.gfm'
         patterns: [
+          {
+            include: 'text.md'
+          }
           {
             include: 'source.gfm'
           }


### PR DESCRIPTION
currently we don't use the syntax from language-markdown, but only use the one from language-gfm.

This PR fixes that so that we use language-markdown instead. Note an user who's not install language-markdown can use syntax from language-gfm as before