### PR TITLE
Support embedded SQL

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -569,6 +569,42 @@ repository:
             name: "punctuation.definition.string.end.julia"
       }
       {
+        begin: '(sql)(""")'
+        beginCaptures:
+          '1':
+            name: 'support.function.macro.julia'
+          '2':
+            name: 'punctuation.definition.string.begin.julia'
+        end: '"""'
+        endCaptures:
+          '0':
+            name: 'punctuation.definition.string.end.julia'
+        name: 'embed.sql.julia'
+        contentName: 'meta.embedded.inline.sql'
+        patterns: [
+          { include: 'source.sql' },
+          { include: '#string_dollar_sign_interpolate' }
+        ]
+      }
+      {
+        begin: '(sql)(")'
+        beginCaptures:
+          '1':
+            name: 'support.function.macro.julia'
+          '2':
+            name: 'punctuation.definition.string.begin.julia'
+        end: '"'
+        endCaptures:
+          '0':
+            name: 'punctuation.definition.string.end.julia'
+        name: 'embed.sql.julia'
+        contentName: 'meta.embedded.inline.sql'
+        patterns: [
+          { include: 'source.sql' },
+          { include: '#string_dollar_sign_interpolate' }
+        ]
+      }
+      {
         begin: "var\"\"\""
         end: "\"\"\""
         name: "constant.other.symbol.julia"


### PR DESCRIPTION
The PR adds support for embedded SQL strings (`@sql_str` macro provided by DBInterface.jl package, see JuliaDatabases/DBInterface.jl#30).

Based on julia-vscode/julia-vscode#1884.