### PR TITLE
fix: correctly tokenize generators in string interpolation

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -776,6 +776,10 @@ repository:
         """
         patterns: [
           {
+            match: '\\bfor\\b'
+            name: 'keyword.control.julia'
+          }
+          {
             include: '#parentheses'
           }
           {

--- a/grammars/julia.json
+++ b/grammars/julia.json
@@ -907,6 +907,10 @@
           "comment": "`punctuation.section.embedded`, `constant.escape`,\n& `meta.embedded.line` were considered but appear to have even spottier\nsupport among popular syntaxes.",
           "patterns": [
             {
+              "match": "\\bfor\\b",
+              "name": "keyword.control.julia"
+            },
+            {
               "include": "#parentheses"
             },
             {

--- a/grammars/julia_vscode.json
+++ b/grammars/julia_vscode.json
@@ -907,6 +907,10 @@
           "comment": "`punctuation.section.embedded`, `constant.escape`,\n& `meta.embedded.line` were considered but appear to have even spottier\nsupport among popular syntaxes.",
           "patterns": [
             {
+              "match": "\\bfor\\b",
+              "name": "keyword.control.julia"
+            },
+            {
               "include": "#parentheses"
             },
             {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/JuliaEditorSupport/atom-language-julia",
   "scripts": {
     "generate": "node ./scripts/generate.js && git add grammars/julia.json && git add grammars/julia_vscode.json",
-    "test": "mocha"
+    "test": "npm run generate && mocha"
   },
   "devDependencies": {
     "chai": "^4.3.7",

--- a/test/test.js
+++ b/test/test.js
@@ -3029,7 +3029,7 @@ describe('Julia grammar', function() {
             scopes: ["source.julia", "string.interpolated.backtick.julia", "punctuation.definition.string.end.julia"]
         });
     });
-    return it("tokenizes interpolated names in multi-line command strings", function() {
+    it("tokenizes interpolated names in multi-line command strings", function() {
         const tokens = tokenize(grammar, '```$_ω!z_.ard!```');
         expect(tokens[0]).to.deep.equal({
             value: '```',
@@ -3046,6 +3046,45 @@ describe('Julia grammar', function() {
         expect(tokens[3]).to.deep.equal({
             value: '```',
             scopes: ["source.julia", "string.interpolated.backtick.julia", "punctuation.definition.string.end.julia"]
+        });
+    });
+    it("tokenizes interpolated generators", function() {
+        const tokens = tokenize(grammar, '"$(a for a in a)"');
+        expect(tokens[0]).to.deep.equal({
+            value: '"',
+            scopes: ["source.julia", "string.quoted.double.julia", "punctuation.definition.string.begin.julia"]
+        });
+        expect(tokens[1]).to.deep.equal({
+            value: "$(",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia"]
+        });
+        expect(tokens[2]).to.deep.equal({
+            value: "a ",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia"]
+        });
+        expect(tokens[3]).to.deep.equal({
+            value: "for",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia", "keyword.control.julia"]
+        });
+        expect(tokens[4]).to.deep.equal({
+            value: " a ",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia"]
+        });
+        expect(tokens[5]).to.deep.equal({
+            value: "in",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia", "keyword.operator.relation.in.julia"]
+        });
+        expect(tokens[6]).to.deep.equal({
+            value: " a",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia"]
+        });
+        expect(tokens[7]).to.deep.equal({
+            value: ")",
+            scopes: ["source.julia", "string.quoted.double.julia", "variable.interpolation.julia"]
+        });
+        expect(tokens[8]).to.deep.equal({
+            value: "\"",
+            scopes: ["source.julia", "string.quoted.double.julia", "punctuation.definition.string.end.julia"]
         });
     });
 })


### PR DESCRIPTION
![image](https://github.com/JuliaEditorSupport/atom-language-julia/assets/6735977/62d3e4e0-e4f9-436f-8047-1cee3068af7e)

Fixes https://github.com/JuliaEditorSupport/atom-language-julia/issues/258.
