### PR TITLE
Add markdown highlighting support in a md multiline string macro

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -494,6 +494,28 @@ repository:
         ]
       }
       {
+        begin: '(md)(""")'
+        beginCaptures:
+          '1':
+            name: 'support.function.macro.julia'
+          '2':
+            name: 'punctuation.definition.string.begin.julia'
+        end: '([\\s\\w]*)(""")'
+        endCaptures:
+          '2':
+            name: 'punctuation.definition.string.end.julia'
+        name: 'embed.markdown.julia'
+        contentName: 'text.html.markdown'
+        patterns: [
+          {
+            include: 'text.html.markdown'
+          }
+          {
+            include: '#string_dollar_sign_interpolate'
+          }
+        ]
+      }
+      {
         begin: '(js)(""")'
         beginCaptures:
           '1':

--- a/grammars/julia.json
+++ b/grammars/julia.json
@@ -560,6 +560,33 @@
           ]
         },
         {
+          "begin": "(md)(\"\"\")",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.macro.julia"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.julia"
+            }
+          },
+          "end": "([\\s\\w]*)(\"\"\")",
+          "endCaptures": {
+            "2": {
+              "name": "punctuation.definition.string.end.julia"
+            }
+          },
+          "name": "embed.markdown.julia",
+          "contentName": "text.html.markdown",
+          "patterns": [
+            {
+              "include": "text.html.markdown"
+            },
+            {
+              "include": "#string_dollar_sign_interpolate"
+            }
+          ]
+        },
+        {
           "begin": "(js)(\"\"\")",
           "beginCaptures": {
             "1": {

--- a/grammars/julia_vscode.json
+++ b/grammars/julia_vscode.json
@@ -560,6 +560,33 @@
           ]
         },
         {
+          "begin": "(md)(\"\"\")",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.macro.julia"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.julia"
+            }
+          },
+          "end": "([\\s\\w]*)(\"\"\")",
+          "endCaptures": {
+            "2": {
+              "name": "punctuation.definition.string.end.julia"
+            }
+          },
+          "name": "embed.markdown.julia",
+          "contentName": "text.html.markdown",
+          "patterns": [
+            {
+              "include": "text.html.markdown"
+            },
+            {
+              "include": "#string_dollar_sign_interpolate"
+            }
+          ]
+        },
+        {
           "begin": "(js)(\"\"\")",
           "beginCaptures": {
             "1": {

--- a/test/test.js
+++ b/test/test.js
@@ -1787,6 +1787,27 @@ describe('Julia grammar', function () {
             },
         ])
     })
+    it("tokenizes markdown multiline string macros", function () {
+        const tokens = tokenize(grammar, 'md"""\nTest\n"""')
+        compareTokens(tokens, [
+            {
+                value: 'md',
+                scopes: ["embed.markdown.julia", "support.function.macro.julia"]
+            },
+            {
+                value: '"""',
+                scopes: ["embed.markdown.julia", "punctuation.definition.string.begin.julia"]
+            },
+            {
+                value: '\nTest\n',
+                scopes: ["embed.markdown.julia"]
+            },
+            {
+                value: '"""',
+                scopes: ["embed.markdown.julia", "punctuation.definition.string.end.julia"]
+            },
+        ])
+    })
     it("tokenizes js multiline string macros", function () {
         const tokens = tokenize(grammar, 'js"""\nvar foo = function () {return x}\n"""')
         compareTokens(tokens, [


### PR DESCRIPTION
A small addition to `julia.json` to allow markdown highlighting support in a md multiline string macro.
Successfully tested with visual-studio-code.